### PR TITLE
Set the source property when sending query

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -45,7 +45,8 @@ export class DataSource extends DataSourceApi<MyQuery, DataSourceOptions> {
         url: this.url + '/api/logs/query',
         method: 'POST',
         data: {
-          query: rawQuery
+          query: rawQuery,
+          source: "grafana-plugin"
         }
       });
       const response = await firstValueFrom(promiseResponse);

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -56,10 +56,6 @@
         {
           "name": "Authorization",
           "content": "Basic {{ .SecureJsonData.sessionToken }}"
-        },
-        {
-          "name": "x-source",
-          "content": "grafana"
         }
       ],
       "urlParams": [


### PR DESCRIPTION
Before sending the query request, set the source property to 'grafana-plugin' for auditing purposes.